### PR TITLE
Fixes bad Content Type Detection

### DIFF
--- a/controllers/podcast.go
+++ b/controllers/podcast.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Migelo/podgrab/model"
 	"github.com/Migelo/podgrab/service"
 	"github.com/gin-contrib/location"
+	"github.com/h2non/filetype"
 
 	"github.com/Migelo/podgrab/db"
 	"github.com/gin-gonic/gin"
@@ -301,16 +302,24 @@ func GetPodcastItemFileById(c *gin.Context) {
 }
 
 func GetFileContentType(filePath string) string {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return "application/octet-stream"
-	}
-	defer file.Close()
-	buffer := make([]byte, 512)
-	if _, err := file.Read(buffer); err != nil {
-		return "application/octet-stream"
-	}
-	return http.DetectContentType(buffer)
+        file, err := os.Open(filePath)
+        if err != nil {
+                fmt.Printf("failed to open %s, err: %v", filePath, err)
+                return "application/octet-stream"
+        }
+        defer file.Close()
+        buffer := make([]byte, 512)
+        _, err = file.Read(buffer);
+        if err != nil {
+                fmt.Printf("failed to read %s, err: %v", filePath, err)
+                return "application/octet-stream"
+        }
+        kind, err := filetype.Match(buffer)
+        if err != nil {
+                fmt.Printf("failed to match %s, err: %v", filePath, err)
+        }
+        return kind.MIME.Value
+        
 }
 
 func MarkPodcastItemAsUnplayed(c *gin.Context) {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gofrs/uuid/v5 v5.3.2
 	github.com/gorilla/websocket v1.5.3
 	github.com/grokify/html-strip-tags-go v0.1.0
+	github.com/h2non/filetype v1.1.3
 	github.com/jasonlvhit/gocron v0.0.1
 	github.com/joho/godotenv v1.5.1
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grokify/html-strip-tags-go v0.1.0 h1:03UrQLjAny8xci+R+qjCce/MYnpNXCtgzltlQbOBae4=
 github.com/grokify/html-strip-tags-go v0.1.0/go.mod h1:ZdzgfHEzAfz9X6Xe5eBLVblWIxXfYSQ40S/VKrAOGpc=
+github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
+github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jasonlvhit/gocron v0.0.1 h1:qTt5qF3b3srDjeOIR4Le1LfeyvoYzJlYpqvG7tJX5YU=
 github.com/jasonlvhit/gocron v0.0.1/go.mod h1:k9a3TV8VcU73XZxfVHCHWMWF9SOqgoku0/QlY2yvlA4=


### PR DESCRIPTION
Many podcasts I listen to were unplayable as http.DetectContentType was unable to properly classify them as audio/mpeg and would default to octet-stream making them unplayable. This library does a much better job, all previously unplayable files now work. No need to change any data in DB etc.

ps. I realize this is a fork of a fork of a fork but looks like you had already done some basic clean up and bumping so instead of duplicating the effort forked from you rather than the original which appears to be abandoned.